### PR TITLE
Fix: regex params for authentication

### DIFF
--- a/src/Actions/User/Validation/UserAuthValidation.php
+++ b/src/Actions/User/Validation/UserAuthValidation.php
@@ -11,7 +11,7 @@ class UserAuthValidation
 {
     private static $regexFirebaseAuthenticationId = '/^[\w]+$/';
     private static $regexFirebaseAuthenticationName = "/^[A-Za-záàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ'\s]+$/";
-    private static $regexFirebaseCloudMessagingDeviceId = '/^[\w:]+$/';
+    private static $regexFirebaseCloudMessagingDeviceId = '/^[\w\-:]+$/';
 
 
     /** @throws ValidationException */


### PR DESCRIPTION
Fix regex for Firebase Cloud Messaging device id